### PR TITLE
Base path feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,28 @@ Both return:
 kula is healthy
 ```
 
+### Reverse Proxy / Sub-path
+
+Set `web.base_path` in `config.yaml` to serve Kula under a URL prefix:
+
+```yaml
+web:
+  base_path: "/kula"   # UI available at https://example.com/kula/
+  trust_proxy: true    # honour X-Forwarded-Proto for the Secure cookie flag
+```
+
+Reverse proxy examples (strip the prefix before forwarding):
+
+```
+# Caddy
+handle_path /kula/* { reverse_proxy localhost:27960 }
+
+# nginx
+location /kula/ { proxy_pass http://localhost:27960/; }
+```
+
+Health endpoints move accordingly: `/kula/health`, `/kula/status`.
+
 ### Authentication (Optional)
 
 ```bash
@@ -304,7 +326,20 @@ sudo ln -s /etc/sv/kula /var/service/
 
 ## ⚙️ Configuration
 
-All settings live in `config.yaml`. See [`config.example.yaml`](config.example.yaml) for defaults.
+All settings live in `config.yaml`. See [`config.example.yaml`](config.example.yaml) for the full reference with defaults.
+
+Key `web:` parameters:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `listen` | `""` (all interfaces) | Bind address |
+| `port` | `27960` | HTTP port |
+| `base_path` | `""` | URL prefix for reverse proxy sub-path deployments |
+| `trust_proxy` | `false` | Trust `X-Forwarded-Proto` for the Secure cookie flag |
+| `max_websocket_conns` | `100` | Global WebSocket connection limit |
+| `max_websocket_conns_per_ip` | `5` | Per-IP WebSocket connection limit |
+
+Environment variable overrides: `KULA_LISTEN`, `KULA_PORT`, `KULA_LOGLEVEL`, `KULA_DIRECTORY`.
 
 ---
 

--- a/addons/docker/Dockerfile
+++ b/addons/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -buildvcs=false -o kula ./cmd/kula/
 
 # ---- Final Stage ----
-FROM alpine:3.21
+FROM docker.io/library/alpine:3.21
 
 # Create unprivileged user
 RUN addgroup -S kula && adduser -S kula -G kula

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,6 +82,12 @@ web:
   max_websocket_conns: 100
   max_websocket_conns_per_ip: 5
 
+  # URL prefix when running behind a reverse proxy sub-path (default: "")
+  # Example: base_path: "/kula" serves the UI at https://example.com/kula/
+  # Caddy: handle_path /kula/* { reverse_proxy localhost:27960 }
+  # Leave empty (or omit) to serve at the root path.
+  base_path: ""
+
   # Trust X-Forwarded-Proto headers from reverse proxies for the Secure cookie flag
   trust_proxy: false
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -455,9 +456,17 @@ func (w WebConfig) CookiePath() string {
 }
 
 // normalizeBasePath cleans a user-supplied base path.
+// Accepts a bare path ("/kula") or a full URL — in the latter case only the
+// path component is kept ("https://host/kula/" → "/kula").
 // Returns "" for root (the default), otherwise a string that starts with "/"
 // and has no trailing slash (e.g. "/kula" or "/monitoring/kula").
 func normalizeBasePath(s string) string {
+	// If a full URL was supplied, extract just the path.
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		if u, err := url.Parse(s); err == nil {
+			s = u.Path
+		}
+	}
 	// Strip trailing slashes
 	for len(s) > 1 && s[len(s)-1] == '/' {
 		s = s[:len(s)-1]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,9 +74,10 @@ type WebConfig struct {
 	OS                 string      `yaml:"-"`
 	Kernel             string      `yaml:"-"`
 	Arch               string      `yaml:"-"`
-	MaxWebsocketConns  int         `yaml:"max_websocket_conns"`
-	MaxWebsocketConnsPerIP int         `yaml:"max_websocket_conns_per_ip"`
-	Security           SecurityConfig `yaml:"security"`
+	MaxWebsocketConns      int            `yaml:"max_websocket_conns"`
+	MaxWebsocketConnsPerIP int            `yaml:"max_websocket_conns_per_ip"`
+	BasePath               string         `yaml:"base_path"`
+	Security               SecurityConfig `yaml:"security"`
 }
 
 // SecurityConfig groups HTTP security features that can be relaxed for
@@ -439,7 +440,37 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
+	cfg.Web.BasePath = normalizeBasePath(cfg.Web.BasePath)
+
 	return cfg, nil
+}
+
+// CookiePath returns the Path attribute for the session cookie.
+// When BasePath is empty the cookie covers the whole site ("/").
+func (w WebConfig) CookiePath() string {
+	if w.BasePath == "" {
+		return "/"
+	}
+	return w.BasePath + "/"
+}
+
+// normalizeBasePath cleans a user-supplied base path.
+// Returns "" for root (the default), otherwise a string that starts with "/"
+// and has no trailing slash (e.g. "/kula" or "/monitoring/kula").
+func normalizeBasePath(s string) string {
+	// Strip trailing slashes
+	for len(s) > 1 && s[len(s)-1] == '/' {
+		s = s[:len(s)-1]
+	}
+	// Treat bare "/" or empty as "no prefix"
+	if s == "" || s == "/" {
+		return ""
+	}
+	// Ensure leading slash
+	if s[0] != '/' {
+		s = "/" + s
+	}
+	return s
 }
 
 // validateOllamaURL ensures the Ollama URL only targets loopback addresses

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -389,7 +389,14 @@ func (s *Server) Start() error {
 		}
 	}()
 
-	var handler = s.securityMiddleware(mux)
+	var root http.Handler = mux
+	if s.cfg.BasePath != "" {
+		outer := http.NewServeMux()
+		outer.Handle(s.cfg.BasePath+"/", http.StripPrefix(s.cfg.BasePath, mux))
+		root = outer
+	}
+
+	var handler = s.securityMiddleware(root)
 	if s.cfg.EnableCompression {
 		handler = gzipMiddleware(handler)
 	}
@@ -759,7 +766,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "kula_session",
 		Value:    token,
-		Path:     "/",
+		Path:     s.cfg.CookiePath(),
 		HttpOnly: true,
 		Secure:   secure,
 		MaxAge:   int(s.cfg.Auth.SessionTimeout.Seconds()),
@@ -793,7 +800,7 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "kula_session",
 		Value:    "",
-		Path:     "/",
+		Path:     s.cfg.CookiePath(),
 		HttpOnly: true,
 		Secure:   secure,
 		MaxAge:   -1,
@@ -1060,12 +1067,14 @@ func (s *Server) renderTemplate(w http.ResponseWriter, r *http.Request, template
 		AuthEnabled bool
 		LangForce   bool
 		EasterEgg   bool
+		BasePath    string
 	}{
 		Nonce:       nonce,
 		SRI:         s.sriHashes,
 		AuthEnabled: s.cfg.Auth.Enabled,
 		LangForce:   s.cfg.Lang.Force,
 		EasterEgg:   s.global.EasterEgg,
+		BasePath:    s.cfg.BasePath,
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -389,14 +389,7 @@ func (s *Server) Start() error {
 		}
 	}()
 
-	var root http.Handler = mux
-	if s.cfg.BasePath != "" {
-		outer := http.NewServeMux()
-		outer.Handle(s.cfg.BasePath+"/", http.StripPrefix(s.cfg.BasePath, mux))
-		root = outer
-	}
-
-	var handler = s.securityMiddleware(root)
+	var handler = s.securityMiddleware(mux)
 	if s.cfg.EnableCompression {
 		handler = gzipMiddleware(handler)
 	}

--- a/internal/web/static/game.html
+++ b/internal/web/static/game.html
@@ -7,6 +7,7 @@
     <title>Space Invaders</title>
     <link rel="icon" href="kula.svg">
     <meta name="description" content="Retro Space Invaders arcade game - an easter egg in the Kulaerver monitor.">
+    <meta name="kula-base" content="{{.BasePath}}">
     <link rel="stylesheet" href="game.css">
 </head>
 
@@ -15,7 +16,7 @@
     <div class="scanlines"></div>
 
     <!-- Back to dashboard -->
-    <a href="/" class="back-link" id="back-link">← <span class="back-text">Dashboard</span></a>
+    <a href="{{.BasePath}}/" class="back-link" id="back-link">← <span class="back-text">Dashboard</span></a>
 
     <!-- HUD -->
     <div class="hud" id="hud">

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -7,6 +7,7 @@
     <title>K U L A</title>
     <link rel="icon" href="kula.svg">
     <meta name="description" content="Lightweight, self-contained Linux® server monitoring tool">
+    <meta name="kula-base" content="{{.BasePath}}">
     <script src="js/chartjs/chart.umd.min.js" integrity="{{sri `chart.umd.min.js`}}" nonce="{{.Nonce}}"
         crossorigin="anonymous"></script>
     <script src="js/chartjs/chartjs-adapter-date-fns.bundle.min.js"
@@ -17,6 +18,7 @@
     <link rel="stylesheet" href="style.css">
 
     <!-- App modules preloading with Subresource Integrity (SRI) -->
+    <link rel="modulepreload" href="js/app/url.js" integrity="{{sri `js/app/url.js`}}" nonce="{{.Nonce}}" crossorigin="anonymous">
     <link rel="modulepreload" href="js/app/state.js" integrity="{{sri `js/app/state.js`}}" nonce="{{.Nonce}}" crossorigin="anonymous">
     <link rel="modulepreload" href="js/app/i18n.js" integrity="{{sri `js/app/i18n.js`}}" nonce="{{.Nonce}}" crossorigin="anonymous">
     <link rel="modulepreload" href="js/app/utils.js" integrity="{{sri `js/app/utils.js`}}" nonce="{{.Nonce}}" crossorigin="anonymous">
@@ -62,7 +64,7 @@
         <!-- Header -->
         <header class="header">
             <div class="header-left">
-                <a href="/" class="header-link"><span class="logo"><img src="kula.svg" alt="" /></span>
+                <a href="{{.BasePath}}/" class="header-link"><span class="logo"><img src="kula.svg" alt="" /></span>
                     <h1>KULA</h1>
                 </a>
                 <span id="hostname" class="hostname"></span>
@@ -129,7 +131,7 @@
                 <!-- AI Assistant -->
                 <button id="btn-ai" class="btn-icon hidden" data-i18n-title="ai_assistant" title="AI Assistant">🤖</button>
                 <!-- Game easter egg -->
-                {{if .EasterEgg}}<a href="/game.html" class="btn-icon btn-game" data-i18n-title="space_invaders" title="Space Invaders"
+                {{if .EasterEgg}}<a href="{{.BasePath}}/game.html" class="btn-icon btn-game" data-i18n-title="space_invaders" title="Space Invaders"
                     id="btn-game">🎮</a>{{end}}
                 <!-- Layout toggle -->
                 <button id="btn-layout" class="btn-icon" data-i18n-title="switch_list"

--- a/internal/web/static/js/app/auth.js
+++ b/internal/web/static/js/app/auth.js
@@ -8,9 +8,10 @@ import { updateAllCharts, clearAllChartData } from './charts-data.js';
 import { connectWS, updateConnectionStatus } from './websocket.js';
 import { applyTheme } from './theme.js';
 import { applySplitFromConfig } from './split.js';
+import { apiUrl } from './url.js';
 
 export function checkAuth() {
-    fetch('/api/auth/status')
+    fetch(apiUrl('/api/auth/status'))
         .then(r => r.json())
         .then(data => {
             if (data.auth_required && !data.authenticated) {
@@ -39,7 +40,7 @@ export function checkAuth() {
 }
 
 export function fetchConfig() {
-    return fetch('/api/config')
+    return fetch(apiUrl('/api/config'))
         .then(r => {
             if (!r.ok) throw new Error('Unauthorized');
             return r.json();
@@ -122,7 +123,7 @@ export function handleLogin(e) {
     const pass = document.getElementById('login-pass')?.value;
     const errorEl = document.getElementById('login-error');
 
-    fetch('/api/login', {
+    fetch(apiUrl('/api/login'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username: user, password: pass }),
@@ -155,7 +156,7 @@ export function handleLogout() {
     if (state.csrfToken) {
         headers['X-CSRF-Token'] = state.csrfToken;
     }
-    fetch('/api/logout', { 
+    fetch(apiUrl('/api/logout'), {
         method: 'POST',
         headers: headers
     })

--- a/internal/web/static/js/app/charts-data.js
+++ b/internal/web/static/js/app/charts-data.js
@@ -5,6 +5,7 @@
 'use strict';
 import { state, colors } from './state.js';
 import { formatBytesShort } from './utils.js';
+import { apiUrl } from './url.js';
 import { createTimeSeriesChart, setChartTimeRange, updateChartLabels } from './charts-init.js';
 import { updateHeader, updateSubtitles } from './header.js';
 import { updateGauges } from './gauges.js';
@@ -1187,7 +1188,7 @@ export function fetchZoomedHistory(fromDate, toDate) {
     const from = fromDate.toISOString();
     const to = toDate.toISOString();
     const points = Math.max(600, window.innerWidth || 1000);
-    fetch(`/api/history?from=${from}&to=${to}&points=${points}`)
+    fetch(apiUrl(`/api/history?from=${from}&to=${to}&points=${points}`))
         .then(r => r.json())
         .then(response => {
             const data = response.samples || response;
@@ -1616,7 +1617,7 @@ export function fetchHistory(rangeSeconds) {
     const to = new Date().toISOString();
     const from = new Date(Date.now() - rangeSeconds * 1000).toISOString();
     const points = Math.max(600, window.innerWidth || 1000);
-    fetch(`/api/history?from=${from}&to=${to}&points=${points}`)
+    fetch(apiUrl(`/api/history?from=${from}&to=${to}&points=${points}`))
         .then(r => r.json())
         .then(response => {
             const data = response.samples || response;
@@ -1696,7 +1697,7 @@ export function fetchCustomHistory(fromDate, toDate) {
     const from = fromDate.toISOString();
     const to = toDate.toISOString();
     const points = Math.max(600, window.innerWidth || 1000);
-    fetch(`/api/history?from=${from}&to=${to}&points=${points}`)
+    fetch(apiUrl(`/api/history?from=${from}&to=${to}&points=${points}`))
         .then(r => r.json())
         .then(response => {
             const data = response.samples || response;
@@ -1761,7 +1762,7 @@ export function fetchGapHistory(fromDate, toDate) {
 
     const from = fromDate.toISOString();
     const to = toDate.toISOString();
-    fetch(`/api/history?from=${from}&to=${to}&points=300`)
+    fetch(apiUrl(`/api/history?from=${from}&to=${to}&points=300`))
         .then(r => r.json())
         .then(response => {
             const data = response.samples || response;

--- a/internal/web/static/js/app/i18n.js
+++ b/internal/web/static/js/app/i18n.js
@@ -3,6 +3,7 @@
    Fetches translations from API and applies them to the DOM.
    ============================================================ */
 'use strict';
+import { apiUrl } from './url.js';
 export const i18n = {
     currentLang: 'en',
     translations: {},
@@ -11,7 +12,7 @@ export const i18n = {
     async init() {
         // Fetch server config first for language settings
         try {
-            const res = await fetch('/api/config');
+            const res = await fetch(apiUrl('/api/config'));
             if (res.ok) {
                 const config = await res.json();
                 this.serverConfig = config.lang || { default: 'en', force: false };
@@ -49,7 +50,7 @@ export const i18n = {
 
     async loadTranslations(lang) {
         try {
-            const response = await fetch(`/api/i18n?lang=${lang}`);
+            const response = await fetch(apiUrl(`/api/i18n?lang=${lang}`));
             if (!response.ok) throw new Error('Failed to load translations');
             this.translations = await response.json();
             this.currentLang = lang;

--- a/internal/web/static/js/app/ollama.js
+++ b/internal/web/static/js/app/ollama.js
@@ -6,6 +6,7 @@
 'use strict';
 import { state, escapeHTML } from './state.js';
 import { i18n } from './i18n.js';
+import { apiUrl } from './url.js';
 
 // ---- Conversation history (max 20 turns kept per session in memory) ----
 const MAX_HISTORY = 20;
@@ -229,7 +230,7 @@ async function fetchSessionContext() {
     try {
         const headers = {};
         if (state.csrfToken) headers['X-CSRF-Token'] = state.csrfToken;
-        const resp = await fetch('/api/ollama/context', { headers });
+        const resp = await fetch(apiUrl('/api/ollama/context'), { headers });
         if (!resp.ok) return;
         const data = await resp.json();
         if (data.context) sess.context = data.context;
@@ -256,7 +257,7 @@ async function pollOllamaModels() {
     try {
         const headers = {};
         if (state.csrfToken) headers['X-CSRF-Token'] = state.csrfToken;
-        const resp = await fetch('/api/ollama/models', { headers });
+        const resp = await fetch(apiUrl('/api/ollama/models'), { headers });
         if (!resp.ok) { setServiceAvailable(false); scheduleModelPoll(5000); return; }
         const data = await resp.json();
         const models = data.models || [];
@@ -635,7 +636,7 @@ async function streamChatResponse({ prompt, messages, context, assistantBody }) 
     const headers = { 'Content-Type': 'application/json' };
     if (state.csrfToken) headers['X-CSRF-Token'] = state.csrfToken;
 
-    const resp = await fetch('/api/ollama/chat', {
+    const resp = await fetch(apiUrl('/api/ollama/chat'), {
         method: 'POST',
         headers,
         body: JSON.stringify({

--- a/internal/web/static/js/app/url.js
+++ b/internal/web/static/js/app/url.js
@@ -1,0 +1,17 @@
+/* ============================================================
+   url.js — Base-path-aware URL helpers.
+   All API fetches and WebSocket connections must go through
+   these helpers so Kula works correctly behind a reverse proxy
+   sub-path (web.base_path config option).
+   When base_path is "" the helpers are transparent no-ops.
+   ============================================================ */
+'use strict';
+
+export const basePath = document.querySelector('meta[name="kula-base"]')?.content ?? '';
+
+export const apiUrl = path => basePath + path;
+
+export function connectWsUrl() {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${location.host}${basePath}/ws`;
+}

--- a/internal/web/static/js/app/websocket.js
+++ b/internal/web/static/js/app/websocket.js
@@ -5,10 +5,10 @@
 'use strict';
 import { state } from './state.js';
 import { pushLiveSample, fetchHistory, fetchGapHistory } from './charts-data.js';
+import { connectWsUrl } from './url.js';
 
 export function connectWS() {
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${proto}//${location.host}/ws`;
+    const wsUrl = connectWsUrl();
 
     try {
         state.ws = new WebSocket(wsUrl);


### PR DESCRIPTION
Disclaimer: it’s Claude generated, I can’t code in Go. 
I tried to be backward compatible.
I don’t understand deep implication of theses changes. 

but it works on my setup. 


 Add `web.base_path` support for reverse proxy sub-path deployments.

  ## Changes
  - `web.base_path` config parameter to serve Kula under a URL prefix (e.g. `/kula`)
  - All static asset paths, API URLs, and WebSocket connections are prefix-aware
  - `web.CookiePath()` scoped to the base path
  - `normalizeBasePath()` accepts both bare paths and full URLs
  - Server-side `StripPrefix` removed — proxy is expected to strip the prefix before forwarding

  ## Documentation
  - New "Reverse Proxy / Sub-path" section in README with Caddy + nginx examples
  - Configuration parameter table added to the ⚙️ Configuration section

  Closes #25

