### PR TITLE
Support container metric collection for Quadlets (Podman via Systemd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Types of changes: Added, Changed, Deprecated, Removed, Fixed, Security
 
 ## [Unreleased]
 
+### Added
+
+- container monitoring: support Podman Quadlet cgroups (#38)
+
 ### Fixed
 
 - keep container chart history across recreate (#39)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -240,8 +240,10 @@ applications:
 
   # Container monitoring (Docker / Podman)
   # Discovery modes (logged at startup):
-  #   - "socket": uses the container runtime API for discovery + cgroups v2 for metrics
-  #   - "cgroups": fallback when no socket is available (no container name mapping)
+  #   - "socket": uses the runtime API for discovery and resolves cgroups v2 via PID
+  #     (supports Podman Quadlets, including rootless services)
+  #   - "cgroups": scans Docker, Podman, and Quadlet cgroups when no socket is
+  #     available (no container name mapping)
   # The socket_path is auto-detected by default; set it explicitly if using a
   # non-standard location or rootless Podman.
   containers:

--- a/internal/collector/containers.go
+++ b/internal/collector/containers.go
@@ -25,6 +25,10 @@ const (
 	containerModeNone   = "none"    // no containers found / not available
 )
 
+// cgroupRoot is a variable so cgroup discovery and PID resolution can be
+// exercised against temporary trees in tests.
+var cgroupRoot = "/sys/fs/cgroup"
+
 // containerCollector runs async container discovery and metric collection.
 type containerCollector struct {
 	mu        sync.RWMutex
@@ -124,7 +128,7 @@ func (cc *containerCollector) resolveSocket() {
 	}
 
 	// Fallback to cgroups-based discovery (no name mapping)
-	if _, err := os.Stat("/sys/fs/cgroup"); err == nil {
+	if _, err := os.Stat(cgroupRoot); err == nil {
 		cc.mode = containerModeCgroup
 		log.Printf("[containers] no runtime socket found, using cgroups-based discovery (container names unavailable)")
 		return
@@ -292,16 +296,31 @@ func (cc *containerCollector) collectViaSocket(elapsed float64) []ContainerStats
 	return stats
 }
 
+// quadletCgroupPatterns returns the common rootful, custom-slice, and rootless
+// systemd layouts used by Podman containers running with cgroups=split.
+func quadletCgroupPatterns(idPattern string) []string {
+	payload := "libpod-payload-" + idPattern
+	return []string{
+		// Rootful/default: system.slice/<unit>.service/libpod-payload-<id>
+		filepath.Join(cgroupRoot, "*.slice", "*.service", payload),
+		// Rootful service placed in a nested custom slice.
+		filepath.Join(cgroupRoot, "*.slice", "*.slice", "*.service", payload),
+		// Rootless/default: user.slice/user-<uid>.slice/user@<uid>.service/
+		// app.slice/<unit>.service/libpod-payload-<id>. The *.slice component
+		// also permits a custom user slice.
+		filepath.Join(cgroupRoot, "user.slice", "user-*.slice", "user@*.service", "*.slice", "*.service", payload),
+	}
+}
+
 // collectViaCgroups enumerates container cgroup directories without API socket.
 // Container names are not available in this mode — IDs are used instead.
 func (cc *containerCollector) collectViaCgroups(elapsed float64) []ContainerStats {
-	cgroupRoot := "/sys/fs/cgroup"
-	// Look for docker scope directories under system.slice
 	patterns := []string{
 		filepath.Join(cgroupRoot, "system.slice", "docker-*.scope"),
 		filepath.Join(cgroupRoot, "system.slice", "libpod-*.scope"),
 		filepath.Join(cgroupRoot, "machine.slice", "libpod-*.scope"),
 	}
+	patterns = append(patterns, quadletCgroupPatterns("*")...)
 
 	var stats []ContainerStats
 	seen := make(map[string]bool)
@@ -313,9 +332,10 @@ func (cc *containerCollector) collectViaCgroups(elapsed float64) []ContainerStat
 		}
 		for _, dir := range matches {
 			base := filepath.Base(dir)
-			// Extract container ID from "docker-<id>.scope" or "libpod-<id>.scope"
+			// Extract the container ID from Docker/Podman scope names and
+			// Podman's split-payload cgroup name.
 			id := base
-			for _, prefix := range []string{"docker-", "libpod-"} {
+			for _, prefix := range []string{"docker-", "libpod-payload-", "libpod-"} {
 				if strings.HasPrefix(id, prefix) {
 					id = strings.TrimPrefix(id, prefix)
 					id = strings.TrimSuffix(id, ".scope")
@@ -354,17 +374,102 @@ func (cc *containerCollector) matchFilter(id, name string) bool {
 	return false
 }
 
+// containerPid queries the runtime's Docker-compatible inspect endpoint for a
+// container's host PID. It returns 0 when inspect is unavailable.
+func (cc *containerCollector) containerPid(id string) int {
+	if cc.client == nil {
+		return 0
+	}
+
+	resp, err := cc.client.Get(fmt.Sprintf("http://localhost/containers/%s/json", id))
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0
+	}
+
+	var info struct {
+		State struct {
+			Pid int `json:"Pid"`
+		} `json:"State"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&info); err != nil {
+		return 0
+	}
+	return info.State.Pid
+}
+
+// containerCgroupPath trims a process cgroup path back to the container root.
+// A payload running systemd may move PID 1 into a child such as init.scope;
+// reading metrics there would omit processes in sibling cgroups.
+func containerCgroupPath(path, id string) string {
+	if id == "" || !strings.HasPrefix(path, "/") {
+		return ""
+	}
+
+	clean := filepath.Clean(path)
+	parts := strings.Split(strings.TrimPrefix(clean, string(filepath.Separator)), string(filepath.Separator))
+	for i, part := range parts {
+		if part == id ||
+			part == "docker-"+id+".scope" ||
+			part == "libpod-"+id+".scope" ||
+			part == "libpod-"+id ||
+			part == "libpod-payload-"+id {
+			return string(filepath.Separator) + filepath.Join(parts[:i+1]...)
+		}
+	}
+	return ""
+}
+
+// cgroupDirFromPid resolves a process's cgroup v2 membership and normalizes it
+// to the matching container root. This supports arbitrary Docker/Podman cgroup
+// parents and Podman Quadlets, including rootless and custom-slice layouts.
+func cgroupDirFromPid(pid int, id string) string {
+	if pid <= 0 {
+		return ""
+	}
+
+	data, err := os.ReadFile(filepath.Join(procPath, strconv.Itoa(pid), "cgroup"))
+	if err != nil {
+		return ""
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) != 3 || fields[0] != "0" || fields[1] != "" {
+			continue
+		}
+
+		path := containerCgroupPath(fields[2], id)
+		if path == "" {
+			continue
+		}
+		dir := filepath.Join(cgroupRoot, strings.TrimPrefix(path, string(filepath.Separator)))
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	return ""
+}
+
 // collectContainerMetrics gathers metrics for a container discovered via socket.
-// It reads cgroups v2 files using the container ID to locate the cgroup directory.
+// It resolves the cgroup via the container PID, then falls back to conventional
+// cgroup paths so an inspect failure does not disable CPU/memory/disk metrics.
 func (cc *containerCollector) collectContainerMetrics(id, name string, elapsed float64) ContainerStats {
 	s := ContainerStats{
 		ID:   id[:minInt(12, len(id))],
 		Name: name,
 	}
 
-	// Find cgroup directory for this container
-	cgroupDir := cc.findCgroupDir(id)
-	cc.debugf("[containers] id=%s name=%s cgroupDir=%q", id, name, cgroupDir)
+	pid := cc.containerPid(id)
+	cgroupDir := cgroupDirFromPid(pid, id)
+	if cgroupDir == "" {
+		cgroupDir = cc.findCgroupDir(id)
+	}
+	cc.debugf("[containers] id=%s name=%s pid=%d cgroupDir=%q", id, name, pid, cgroupDir)
 	if cgroupDir == "" {
 		return s
 	}
@@ -378,8 +483,11 @@ func (cc *containerCollector) collectContainerMetrics(id, name string, elapsed f
 		s.MemPct = round2(float64(s.MemUsed) / float64(s.MemLimit) * 100)
 	}
 
-	// Network I/O (via /proc/<pid>/net/dev — needs container PID)
-	s.NetRxBPS, s.NetTxBPS = cc.readNetIO(id, elapsed)
+	// Network I/O requires the runtime PID; the other metrics remain available
+	// through direct cgroup fallback when inspect is unavailable.
+	if pid > 0 {
+		s.NetRxBPS, s.NetTxBPS = cc.readNetIO(pid, id, elapsed)
+	}
 
 	// Disk I/O from io.stat
 	s.DiskRBPS, s.DiskWBPS = cc.readDiskIO(cgroupDir, id, elapsed)
@@ -407,13 +515,27 @@ func (cc *containerCollector) collectContainerMetricsCgroup(cgroupDir, id, short
 // findCgroupDir locates the cgroup v2 directory for a container ID.
 func (cc *containerCollector) findCgroupDir(id string) string {
 	candidates := []string{
-		filepath.Join("/sys/fs/cgroup/system.slice", "docker-"+id+".scope"),
-		filepath.Join("/sys/fs/cgroup/system.slice", "libpod-"+id+".scope"),
-		filepath.Join("/sys/fs/cgroup/machine.slice", "libpod-"+id+".scope"),
+		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope"),
+		filepath.Join(cgroupRoot, "system.slice", "libpod-"+id+".scope"),
+		filepath.Join(cgroupRoot, "machine.slice", "libpod-"+id+".scope"),
+		filepath.Join(cgroupRoot, "docker", id),
+		filepath.Join(cgroupRoot, "libpod-"+id),
 	}
 	for _, path := range candidates {
-		if _, err := os.Stat(path); err == nil {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
 			return path
+		}
+	}
+
+	for _, pattern := range quadletCgroupPatterns(id) {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, path := range matches {
+			if info, err := os.Stat(path); err == nil && info.IsDir() {
+				return path
+			}
 		}
 	}
 	return ""
@@ -444,32 +566,9 @@ func (cc *containerCollector) readCPUUsage(cgroupDir, id string, elapsed float64
 	return cpuPct
 }
 
-// readNetIO reads network I/O for a container by looking up its PID.
-func (cc *containerCollector) readNetIO(id string, elapsed float64) (rxBPS, txBPS float64) {
-	if cc.client == nil {
-		return
-	}
-
-	// Get container PID from inspect API
-	resp, err := cc.client.Get(fmt.Sprintf("http://localhost/containers/%s/json", id))
-	if err != nil {
-		return
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var info struct {
-		State struct {
-			Pid int `json:"Pid"`
-		} `json:"State"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil || info.State.Pid == 0 {
-		return
-	}
-
-	cc.debugf("[containers] id=%s pid=%d", id, info.State.Pid)
-
-	// Read /proc/<pid>/net/dev
-	netDevPath := filepath.Join("/proc", strconv.Itoa(info.State.Pid), "net/dev")
+// readNetIO reads network I/O for a container from /proc/<pid>/net/dev.
+func (cc *containerCollector) readNetIO(pid int, id string, elapsed float64) (rxBPS, txBPS float64) {
+	netDevPath := filepath.Join(procPath, strconv.Itoa(pid), "net/dev")
 	f, err := os.Open(netDevPath)
 	if err != nil {
 		return

--- a/internal/collector/containers_test.go
+++ b/internal/collector/containers_test.go
@@ -15,6 +15,37 @@ func TestContainerCollector(t *testing.T) {
 	sockPath := "/tmp/container_test.sock"
 	defer func() { _ = os.Remove(sockPath) }()
 
+	// Make the inspect PID resolve to a Quadlet split-payload cgroup.
+	origRoot, origProc := cgroupRoot, procPath
+	cgroupRoot, procPath = t.TempDir(), t.TempDir()
+	defer func() { cgroupRoot, procPath = origRoot, origProc }()
+
+	const id = "c1234567890abcdef"
+	cgroupRel := filepath.Join("system.slice", "test.service", "libpod-payload-"+id)
+	cgroupDir := filepath.Join(cgroupRoot, cgroupRel)
+	if err := os.MkdirAll(cgroupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"memory.current": "104857600\n",
+		"memory.max":     "209715200\n",
+		"memory.stat":    "inactive_file 0\n",
+	} {
+		if err := os.WriteFile(filepath.Join(cgroupDir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(procPath, "123"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(procPath, "123", "cgroup"),
+		[]byte("0::/"+filepath.ToSlash(cgroupRel)+"\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	// Mock Docker/Podman socket server
 	listener, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -27,12 +58,12 @@ func TestContainerCollector(t *testing.T) {
 		// List containers
 		mux.HandleFunc("/containers/json", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprintf(w, `[{"Id":"c1234567890abcdef","Names":["/test-container"],"State":"running"}]`)
+			_, _ = fmt.Fprintf(w, `[{"Id":"%s","Names":["/test-container"],"State":"running"}]`, id)
 		})
 		// Container inspect (for PID)
-		mux.HandleFunc("/containers/c1234567890abcdef/json", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/containers/"+id+"/json", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprintf(w, `{"State":{"Pid":123}}`)
+			_, _ = fmt.Fprint(w, `{"State":{"Pid":123}}`)
 		})
 		server := http.Server{Handler: mux}
 		_ = server.Serve(listener)
@@ -67,8 +98,11 @@ func TestContainerCollector(t *testing.T) {
 	if s.Name != "test-container" {
 		t.Errorf("Expected test-container, got %s", s.Name)
 	}
-	if !strings.HasPrefix("c1234567890abcdef", s.ID) { //nolint:gocritic // argOrder: intentionally checks s.ID is a prefix of the mock ID
+	if !strings.HasPrefix(id, s.ID) {
 		t.Errorf("Expected s.ID to be a prefix of the mock ID, got %s", s.ID)
+	}
+	if s.MemUsed != 104857600 {
+		t.Errorf("MemUsed = %d, want 104857600", s.MemUsed)
 	}
 }
 
@@ -137,5 +171,144 @@ func TestContainerCollectorCgroupDetect(t *testing.T) {
 	// We just want to ensure it doesn't crash and handles the nonexistent socket.
 	if cc.mode == containerModeSocket {
 		t.Error("Should not be in socket mode for nonexistent socket")
+	}
+}
+
+func TestCgroupDirFromPidNormalizesContainerRoot(t *testing.T) {
+	origRoot, origProc := cgroupRoot, procPath
+	cgroupRoot, procPath = t.TempDir(), t.TempDir()
+	defer func() { cgroupRoot, procPath = origRoot, origProc }()
+
+	tests := []struct {
+		name string
+		pid  int
+		id   string
+		root string
+		leaf string
+	}{
+		{
+			name: "quadlet payload running systemd",
+			pid:  100,
+			id:   strings.Repeat("a", 64),
+			root: filepath.Join("system.slice", "myapp.service", "libpod-payload-"+strings.Repeat("a", 64)),
+			leaf: "init.scope",
+		},
+		{
+			name: "rootless quadlet custom slice",
+			pid:  101,
+			id:   strings.Repeat("b", 64),
+			root: filepath.Join(
+				"user.slice", "user-1000.slice", "user@1000.service", "apps.slice",
+				"myapp.service", "libpod-payload-"+strings.Repeat("b", 64),
+			),
+			leaf: filepath.Join("system.slice", "worker.service"),
+		},
+		{
+			name: "docker payload running systemd",
+			pid:  102,
+			id:   strings.Repeat("c", 64),
+			root: filepath.Join("system.slice", "docker-"+strings.Repeat("c", 64)+".scope"),
+			leaf: "init.scope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := filepath.Join(cgroupRoot, tt.root)
+			if err := os.MkdirAll(filepath.Join(root, tt.leaf), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			pidDir := filepath.Join(procPath, fmt.Sprint(tt.pid))
+			if err := os.MkdirAll(pidDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			content := "12:pids:/ignored-v1-path\n0::/" + filepath.ToSlash(filepath.Join(tt.root, tt.leaf)) + "\n"
+			if err := os.WriteFile(filepath.Join(pidDir, "cgroup"), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := cgroupDirFromPid(tt.pid, tt.id); got != root {
+				t.Errorf("cgroupDirFromPid(%d) = %q, want %q", tt.pid, got, root)
+			}
+			if got := cgroupDirFromPid(tt.pid, strings.Repeat("d", 64)); got != "" {
+				t.Errorf("cgroupDirFromPid with mismatched ID = %q, want empty", got)
+			}
+		})
+	}
+
+	if got := cgroupDirFromPid(99999, strings.Repeat("e", 64)); got != "" {
+		t.Errorf("cgroupDirFromPid for missing process = %q, want empty", got)
+	}
+}
+
+func TestCollectContainerMetricsFallsBackWithoutInspect(t *testing.T) {
+	origRoot := cgroupRoot
+	cgroupRoot = t.TempDir()
+	defer func() { cgroupRoot = origRoot }()
+
+	id := strings.Repeat("d", 64)
+	dir := filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"memory.current": "67108864\n",
+		"memory.max":     "134217728\n",
+		"memory.stat":    "inactive_file 0\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cc := &containerCollector{
+		prevCPU:  make(map[string]containerCPURaw),
+		prevNet:  make(map[string]containerNetRaw),
+		prevDisk: make(map[string]containerDiskRaw),
+	}
+	got := cc.collectContainerMetrics(id, "fallback-test", 1)
+	if got.MemUsed != 67108864 || got.MemLimit != 134217728 {
+		t.Errorf("fallback memory = %d/%d, want 67108864/134217728", got.MemUsed, got.MemLimit)
+	}
+}
+
+func TestCollectViaCgroupsDiscoversQuadlets(t *testing.T) {
+	origRoot := cgroupRoot
+	cgroupRoot = t.TempDir()
+	defer func() { cgroupRoot = origRoot }()
+
+	rootfulID := strings.Repeat("a", 64)
+	rootlessID := strings.Repeat("b", 64)
+	scopeID := strings.Repeat("c", 64)
+	for _, dir := range []string{
+		filepath.Join(cgroupRoot, "system.slice", "rootful.service", "libpod-payload-"+rootfulID),
+		filepath.Join(
+			cgroupRoot, "user.slice", "user-1000.slice", "user@1000.service",
+			"app.slice", "rootless.service", "libpod-payload-"+rootlessID,
+		),
+		filepath.Join(cgroupRoot, "system.slice", "libpod-"+scopeID+".scope"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cc := &containerCollector{
+		prevCPU:  make(map[string]containerCPURaw),
+		prevDisk: make(map[string]containerDiskRaw),
+	}
+	stats := cc.collectViaCgroups(1)
+
+	ids := make(map[string]bool)
+	for _, stat := range stats {
+		ids[stat.ID] = true
+	}
+	for _, id := range []string{rootfulID[:12], rootlessID[:12], scopeID[:12]} {
+		if !ids[id] {
+			t.Errorf("container %s not discovered; got %+v", id, stats)
+		}
+	}
+	if len(stats) != 3 {
+		t.Errorf("got %d containers, want 3: %+v", len(stats), stats)
 	}
 }


### PR DESCRIPTION
When running as quadlet, the cgroup directory uses a different naming format than plain libpod/podman. Instead, resolve the cgroup path via `/proc/<pid>/cgroup`. The container PID was already resolved via a docker inspect call in `readNetIO`, this has been hoisted into a separate `containerPid` function.

Podman actually exposes the cgroup directory directly in the API, but docker does not, which is why I went with this approach.

The fallback case where no socket/API is available has been amended as well to scan for quadlet-style
paths (cgroup/system.slice/<unit>.service/libpod-payload-<id>).

This was written with the help of Deepseek V4 Pro. I tried to keep it minimal. I diagnosed the issue myself first, and I reviewed and tested the code afterwards.