### PR TITLE
fix(dashboard): keep container chart history across recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Types of changes: Added, Changed, Deprecated, Removed, Fixed, Security
 
+## [Unreleased]
+
+### Fixed
+
+- dashboard: keep container chart history across recreate by keying series on
+  container name (fall back to id when name is unavailable), instead of Docker
+  container id which changes on every recreate
+
 ## [0.18.6] - 2026-07-11
 
 ### Added

--- a/internal/web/static/js/app/charts-data.js
+++ b/internal/web/static/js/app/charts-data.js
@@ -21,6 +21,14 @@ const APP_ORDER_POSTGRES = 30;
 const APP_ORDER_MYSQL = 38;
 const APP_ORDER_CUSTOM = 50;
 
+// Stable chart key for a container sample. Prefer the human-readable name so
+// history survives recreate (Docker assigns a new ID each time). Fall back to
+// id when name is empty (cgroups-only discovery has no names).
+function containerSeriesKey(ct) {
+    const raw = (ct.name && String(ct.name).trim()) || ct.id || 'unknown';
+    return 'container_' + String(raw).replace(/[^a-zA-Z0-9_-]+/g, '_');
+}
+
 // createAppChartCard creates a chart-card DOM structure in the applications
 // grid and returns the canvas ID for use with createTimeSeriesChart.
 function createAppChartCard(cardId, chartId, subtitleId, title, order) {
@@ -712,7 +720,7 @@ export function addSampleToCharts(item, ts) {
     if (s.apps?.containers?.length > 0) {
         appsVisible = true;
         for (const ct of s.apps.containers) {
-            const base = `container_${ct.id}`;
+            const base = containerSeriesKey(ct);
             const cpuKey = `${base}_cpu`;
             const memKey = `${base}_mem`;
             const ioKey  = `${base}_io`;

--- a/internal/web/static/js/app/state.js
+++ b/internal/web/static/js/app/state.js
@@ -64,7 +64,7 @@ export const state = {
     splitDiskTemp: JSON.parse(localStorage.getItem('kula_split_disktemp') || 'false'),
     splitGpu: JSON.parse(localStorage.getItem('kula_split_gpu') || 'false'),
     splitCharts: {}, // { type: { chartKey: chartInstance } }
-    containerCharts: {}, // { container_<id>: chartInstance }
+    containerCharts: {}, // { container_<name|id>_cpu|mem|io: chartInstance }
     customCharts: {}, // { group_name: chartInstance }
     customMetricsConfig: {}, // { group_name: [{name, unit, max}, ...] } from /api/config
 };


### PR DESCRIPTION
## Summary

Container dashboard charts were keyed by Docker **container id**. On recreate, Docker issues a new id while the **name** (e.g. `app-tchessy`) usually stays the same. Older samples remain in Kula storage under the same name, but the UI only plotted the current incarnation.

## Fix

Key chart series by **container name** (DOM-safe), falling back to **id** when name is empty (cgroups-only discovery has no names).

## Test plan

- [ ] Run Kula with Docker containers monitored
- [ ] Note memory chart for a named container over several minutes
- [ ] `docker compose up -d --force-recreate` (or equivalent) for that service
- [ ] Reload history for a window that spans the recreate: one continuous series under the container name, including pre-recreate points
- [ ] Cgroups-only / unnamed path still works (key falls back to id)
