### PR TITLE
fix(dashboard): keep time range controls sticky while scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Types of changes: Added, Changed, Deprecated, Removed, Fixed, Security
 
+## [Unreleased]
+
+### Changed
+
+- keep time range controls sticky under the header while scrolling the dashboard
+
 ## [0.18.7] - 2026-07-26
 
 ### Added

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -63,6 +63,8 @@
 
     <!-- Main dashboard -->
     <div id="dashboard" class="dashboard">
+        <!-- Sticky top: main header + time/aggregation controls stay visible while scrolling -->
+        <div class="sticky-topbar">
         <!-- Header -->
         <header class="header">
             <div class="header-left">
@@ -182,41 +184,7 @@
             </div>
         </header>
 
-        <!-- Gauges row -->
-        <section class="gauges-row" id="gauges-row">
-            <div class="gauge-card" id="gauge-cpu">
-                <div id="gauge-cpu-canvas"></div>
-                <div class="gauge-label" data-i18n="cpu">CPU</div>
-                <div class="gauge-value" id="gauge-cpu-value">0%</div>
-            </div>
-            <div class="gauge-card" id="gauge-ram">
-                <div id="gauge-ram-canvas"></div>
-                <div class="gauge-label" data-i18n="ram">RAM</div>
-                <div class="gauge-value" id="gauge-ram-value">0%</div>
-            </div>
-            <div class="gauge-card" id="gauge-swap">
-                <div id="gauge-swap-canvas"></div>
-                <div class="gauge-label" data-i18n="swap">SWAP</div>
-                <div class="gauge-value" id="gauge-swap-value">0%</div>
-            </div>
-            <div class="gauge-card" id="gauge-lavg">
-                <div id="gauge-lavg-canvas"></div>
-                <div class="gauge-label" data-i18n="load_avg">Load Avg (1m)</div>
-                <div class="gauge-value" id="gauge-lavg-value">0.00</div>
-            </div>
-            <div class="gauge-card" id="gauge-dl">
-                <div id="gauge-dl-canvas"></div>
-                <div class="gauge-label" data-i18n="download">↓ Download</div>
-                <div class="gauge-value" id="gauge-dl-value">0 Mbps</div>
-            </div>
-            <div class="gauge-card" id="gauge-ul">
-                <div id="gauge-ul-canvas"></div>
-                <div class="gauge-label" data-i18n="upload">↑ Upload</div>
-                <div class="gauge-value" id="gauge-ul-value">0 Mbps</div>
-            </div>
-        </section>
-
-        <!-- Time controls -->
+        <!-- Time controls (sticky with header so they stay reachable while scrolling charts) -->
         <section class="time-controls">
             <div class="time-presets">
                 <button id="btn-time-menu" class="btn-icon btn-time-menu" data-i18n-title="time_presets"
@@ -261,6 +229,41 @@
             <input type="datetime-local" id="custom-to" class="time-input">
             <button class="time-btn time-apply" id="btn-apply-custom" data-i18n="apply">Apply</button>
         </div>
+        </div><!-- /.sticky-topbar -->
+
+        <!-- Gauges row -->
+        <section class="gauges-row" id="gauges-row">
+            <div class="gauge-card" id="gauge-cpu">
+                <div id="gauge-cpu-canvas"></div>
+                <div class="gauge-label" data-i18n="cpu">CPU</div>
+                <div class="gauge-value" id="gauge-cpu-value">0%</div>
+            </div>
+            <div class="gauge-card" id="gauge-ram">
+                <div id="gauge-ram-canvas"></div>
+                <div class="gauge-label" data-i18n="ram">RAM</div>
+                <div class="gauge-value" id="gauge-ram-value">0%</div>
+            </div>
+            <div class="gauge-card" id="gauge-swap">
+                <div id="gauge-swap-canvas"></div>
+                <div class="gauge-label" data-i18n="swap">SWAP</div>
+                <div class="gauge-value" id="gauge-swap-value">0%</div>
+            </div>
+            <div class="gauge-card" id="gauge-lavg">
+                <div id="gauge-lavg-canvas"></div>
+                <div class="gauge-label" data-i18n="load_avg">Load Avg (1m)</div>
+                <div class="gauge-value" id="gauge-lavg-value">0.00</div>
+            </div>
+            <div class="gauge-card" id="gauge-dl">
+                <div id="gauge-dl-canvas"></div>
+                <div class="gauge-label" data-i18n="download">↓ Download</div>
+                <div class="gauge-value" id="gauge-dl-value">0 Mbps</div>
+            </div>
+            <div class="gauge-card" id="gauge-ul">
+                <div id="gauge-ul-canvas"></div>
+                <div class="gauge-label" data-i18n="upload">↑ Upload</div>
+                <div class="gauge-value" id="gauge-ul-value">0 Mbps</div>
+            </div>
+        </section>
 
         <!-- Charts grid -->
         <h2 class="section-title" data-i18n="system_metrics">System Metrics</h2>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -200,6 +200,17 @@ body {
     }
 }
 
+/* ---- Sticky topbar (header + time controls) ----
+   Keeps the time range / aggregation controls reachable while scrolling
+   long dashboards (many application/container charts). */
+.sticky-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    /* Opaque enough that chart content does not show through while stuck */
+    background: var(--bg-primary);
+}
+
 /* ---- Header ---- */
 .header {
     display: flex;
@@ -209,9 +220,9 @@ body {
     background: var(--bg-card);
     border-bottom: 1px solid var(--border-color);
     backdrop-filter: blur(10px);
-    position: sticky;
-    top: 0;
-    z-index: 100;
+    /* Sticky is owned by .sticky-topbar so header + time bar move as one unit */
+    position: relative;
+    z-index: 1;
 }
 
 .header-left,
@@ -597,6 +608,8 @@ body {
     border-bottom: 1px solid var(--border-color);
     flex-wrap: wrap;
     gap: 0.5rem;
+    background: var(--bg-card);
+    backdrop-filter: blur(10px);
 }
 
 .time-presets {
@@ -665,6 +678,8 @@ body {
     padding: 0.5rem 1.5rem;
     border-bottom: 1px solid var(--border-color);
     flex-wrap: wrap;
+    background: var(--bg-card);
+    backdrop-filter: blur(10px);
 }
 
 .time-input {
@@ -1151,7 +1166,8 @@ body.light-mode .focus-selecting .chart-card::after {
         border-radius: var(--radius);
         padding: 0.5rem;
         flex-direction: column;
-        z-index: 100;
+        /* Above sticky topbar siblings / chart content */
+        z-index: 110;
         box-shadow: var(--shadow-lg);
         margin-top: 0.5rem;
         min-width: 120px;


### PR DESCRIPTION
## Problem

On a long dashboard — especially once **Applications / container charts** fill several screens — the time selection bar sits mid-page and **scrolls out of view**.

That bar is how you pick the history window:

- presets: `1m`, `5m`, `15m`, … `30d`
- aggregation: avg / min / max
- custom range
- the current sampling label (e.g. **Tier 1 (raw)** / aggregated tiers)

So if you are looking at a container near the bottom and want to switch from 5 minutes to 3 hours (or check which tier is loaded), you have to:

1. scroll all the way to the top  
2. change the timeframe  
3. scroll all the way back down to the chart you were watching  

That is slow and easy to lose your place. The main header was already sticky; the time controls were not.

## Intent

Keep the **time / aggregation controls always reachable** while scrolling, without cluttering the page or changing how the controls work.

Place them **immediately under the header** and stick **header + time bar as one unit** so they stay visible at the top of the viewport.

## Change

- Wrap the main header, time-controls row, and custom-range row in a `.sticky-topbar` (`position: sticky; top: 0`)
- Move time controls from below the gauges row to **directly under the header** (gauges still scroll with content)
- Give the time bar (and custom-range row) a solid card background so chart content does not show through while stuck
- Slightly raise mobile preset dropdown `z-index` so it paints above sticky siblings

No JS behavior change: same buttons, same IDs, same history fetch paths.

## Test plan

- [ ] Open dashboard with enough charts to scroll (several containers helps)
- [ ] Confirm time bar sits under the header (before gauges)
- [ ] Scroll deep into Applications: presets + aggregation + tier label remain visible
- [ ] Change range (e.g. 5m → 1h → 24h) without scrolling up; charts update as before
- [ ] Toggle custom range: picker appears under the sticky bar and stays usable
- [ ] Mobile / narrow width: time menu dropdown still opens and is clickable
- [ ] Light and dark theme: no transparent “see-through” bar over charts
